### PR TITLE
Memperbaiki Konfigurasi CORS dan Menghapus access_token dari Respons Auth

### DIFF
--- a/backend/src/handlers/authHandler.js
+++ b/backend/src/handlers/authHandler.js
@@ -163,7 +163,6 @@ const authStatusHandler = async (request, h) => {
     .response({
       event: event,
       session: {
-        access_token: session.access_token,
         user: {
           id: session.user.id,
           email: session.user.email,

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -10,7 +10,10 @@ const init = async () => {
     host: "localhost",
     routes: {
       cors: {
-        origin: ["*"],
+        origin: process.env.CORS_ORIGIN.split(","),
+        credentials: true,
+        additionalHeaders: ["Authorization", "Content-Type"],
+        additionalExposedHeaders: ["Authorization"],
       },
     },
   });


### PR DESCRIPTION
Memperbaiki konfigurasi CORS untuk membatasi asal permintaan, memastikan hanya domain yang diizinkan dapat mengakses API. Dan juga menghapus access_token dari respons handler authStatusHandler 